### PR TITLE
Changed an incorrect Exporter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a list of exporters that implement the CommonMCOBJ spec.
 | Exporter                                          | CommonMC Version | Appears in | Supported Operating Systems | Additional Notes                                                                                                                                                                            |
 | ------------------------------------------------- | ---------------- | ---------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Mineways](https://github.com/erich666/Mineways/) | V1               | v11.07     | Windows<sup>[1]</sup>                  | Mineways contains an additional header with much more information about the export. More of those options may be added to CommonMCOBJ in the future.                                                     |
-| [jcm2OBJ](https://github.com/jmc2obj/j-mc-2-obj/)  | V1               | 124       | Any platform with JVM       ||
+| [jMc2Obj](https://github.com/jmc2obj/j-mc-2-obj/)  | V1               | 124       | Any platform with JVM       ||
 | [cmc2OBJ](https://github.com/CommonMCOBJ/cmc2obj/)  | V1               | v1.0       | Any platform with JVM       | cmc2OBJ is the reference implementation of CommonMCOBJ and is intended for developers. In addition, cmc2OBJ is forked from jmc2OBJ, but will deviate as more parts are converted to Kotlin. |
 
 [1]: Can be ran on non-Windows systems with WINE


### PR DESCRIPTION
This pull request just changes `jcm2OBJ` to `jMc2Obj` in the list, would like to merge them if possible 😉